### PR TITLE
app/bnapi: parse validator ids query string as beacon node API spec says

### DIFF
--- a/app/bnapi/bnapi.go
+++ b/app/bnapi/bnapi.go
@@ -291,7 +291,6 @@ func (vsh *validatorStateHandler) getValidator(singleValidatorQuery bool) http.H
 			valIDs = append(valIDs, val)
 		} else {
 			valIDs = request.URL.Query()["id"]
-			fmt.Println("validator ids:", valIDs)
 			if len(valIDs) == 0 {
 				validatorNotFound(writer)
 				return


### PR DESCRIPTION
Get the entire query string array, not just one element.

category: bug
ticket: none