### PR TITLE
app/obolapi: hex-encode k1 signatures

### DIFF
--- a/app/obolapi/obolapi.go
+++ b/app/obolapi/obolapi.go
@@ -5,7 +5,6 @@ package obolapi
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -48,7 +47,7 @@ func partialExitURL(lockHash string) string {
 
 // bearerString returns the bearer token authentication string given a token.
 func bearerString(data []byte) string {
-	return fmt.Sprintf("Bearer %s", base64.StdEncoding.EncodeToString(data))
+	return fmt.Sprintf("Bearer %#x", data)
 }
 
 // fullExitURL returns the full exit Obol API URL for a given validator public key.

--- a/app/obolapi/test_server.go
+++ b/app/obolapi/test_server.go
@@ -4,7 +4,6 @@ package obolapi
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"net/http"
@@ -328,9 +327,9 @@ func authMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		bearerBytes, err := base64.StdEncoding.DecodeString(bearer)
+		bearerBytes, err := util.K1SignatureToBytes(bearer)
 		if err != nil {
-			writeErr(w, http.StatusBadRequest, "bearer token must be base64-encoded")
+			writeErr(w, http.StatusBadRequest, "bearer token must be hex-encoded")
 			return
 		}
 

--- a/app/util/util.go
+++ b/app/util/util.go
@@ -19,6 +19,9 @@ const (
 
 	// lockHashLen is the amount of bytes a well-formed lock hash must contain.
 	lockHashLen = 32
+
+	// k1SignatureLen is the amount of bytes a well-formed K1 signature must contain.
+	k1SignatureLen = 65
 )
 
 // from0x decodes hex-encoded data and expects it to be exactly of len(length).
@@ -58,4 +61,10 @@ func SignatureToBytes(signature string) ([]byte, error) {
 // If lockHash is empty, contains badly-formatted hex data or doesn't yield exactly 32 bytes, this function will error.
 func LockHashToBytes(lockHash string) ([]byte, error) {
 	return from0x(lockHash, lockHashLen)
+}
+
+// K1SignatureToBytes returns the bytes representation of the hex-encoded K1 signature string passed in input.
+// If signature is empty, contains badly-formatted hex data or doesn't yield exactly 32 bytes, this function will error.
+func K1SignatureToBytes(signature string) ([]byte, error) {
+	return from0x(signature, k1SignatureLen)
 }

--- a/app/util/util_test.go
+++ b/app/util/util_test.go
@@ -158,3 +158,52 @@ func TestLockHashToBytes(t *testing.T) {
 		})
 	}
 }
+
+func TestK1SignatureToBytes(t *testing.T) {
+	tests := []struct {
+		name    string
+		pubkey  string
+		want    []byte
+		wantErr bool
+	}{
+		{
+			"empty input",
+			"",
+			nil,
+			true,
+		},
+		{
+			"not 65 bytes",
+			hex.EncodeToString([]byte{1, 2, 3}),
+			nil,
+			true,
+		},
+		{
+			"65 bytes 0x-prefixed work",
+			"0x" + hex.EncodeToString(bytes.Repeat([]byte{42}, 65)),
+			bytes.Repeat([]byte{42}, 65),
+			false,
+		},
+		{
+			"65 bytes non-0x-prefixed work",
+			hex.EncodeToString(bytes.Repeat([]byte{42}, 65)),
+			bytes.Repeat([]byte{42}, 65),
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := util.K1SignatureToBytes(tt.pubkey)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Empty(t, got)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Instead of base64 use hex, which is more common in the Ethereum ecosystem.

category: refactor
ticket: none