### PR TITLE
app/keystore: add method to just load cluster lock

### DIFF
--- a/app/keystore/keystore.go
+++ b/app/keystore/keystore.go
@@ -72,8 +72,8 @@ func (vs ValidatorShares) ValidatorsPhase0() ([]eth2p0.BLSPubKey, error) {
 	return ret, nil
 }
 
-// clusterFile returns the *manifestpb.Cluster file contained in dir.
-func clusterFile(dir string) (*manifestpb.Cluster, error) {
+// LoadClusterLock returns the *manifestpb.Cluster file contained in dir.
+func LoadClusterLock(dir string) (*manifestpb.Cluster, error) {
 	// try opening the lock file
 	lockFile := filepath.Join(dir, "cluster-lock.json")
 	manifestFile := filepath.Join(dir, "cluster-manifest.pb")
@@ -98,7 +98,7 @@ func LoadManifest(dir string) (*manifestpb.Cluster, []tbls.PrivateKey, error) {
 		return nil, nil, errors.Wrap(err, "can't read directory")
 	}
 
-	cl, err := clusterFile(dir)
+	cl, err := LoadClusterLock(dir)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/mockservers.go
+++ b/cmd/mockservers.go
@@ -87,7 +87,7 @@ func newMockServersCmd(
 
 		userProvidedValAmt := len(bcc.Validators)
 
-		cl, _, err := keystore.LoadManifest(filepath.Dir(bcc.LockFilePath))
+		cl, err := keystore.LoadClusterLock(filepath.Dir(bcc.LockFilePath))
 		if err != nil {
 			return errors.Wrap(err, "lockfile load error")
 		}


### PR DESCRIPTION
It's used in `mockservers`.

category: refactor
ticket: none
