### PR TITLE
app: increase beacon node timeout

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,7 @@ jobs:
       # Config options can be found in README here: https://github.com/golangci/golangci-lint-action
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21.3'
+          go-version: '1.21.5'
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -16,6 +16,6 @@ jobs:
           ssh-key: ${{ secrets.DEPLOY_KEY }}
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21.3'
+          go-version: '1.21.5'
       - run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - run: govulncheck -show=stacks -test ./...

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-python@v2
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21.3'
+          go-version: '1.21.5'
       - uses: pre-commit/action@v2.0.3
 
       - name: notify failure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         fetch-depth: 0 # Disable shallow checkout
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.21.3'
+        go-version: '1.21.5'
     - run: go run . --help > cli-reference.txt
     - run: go run testutil/genchangelog/main.go
     - uses: softprops/action-gh-release@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21.3'
+          go-version: '1.21.5'
       - uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21.3'
+          go-version: '1.21.5'
 
       - name: "Verify PR"
         run: go run github.com/obolnetwork/charon/testutil/verifypr

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 run:
   timeout: 5m
-  go: "1.21.3"
+  go: "1.21.5"
 linters-settings:
   cyclop:
     max-complexity: 15
@@ -89,7 +89,7 @@ linters-settings:
          - "github.com/gogo/protobuf/proto" # Prefer google.golang.org/protobuf
          - "github.com/prometheus/client_golang/prometheus/promauto" # Prefer ./app/promauto
   staticcheck:
-    go: "1.21.3"
+    go: "1.21.5"
     checks:
      - "all"
      - "-SA1019" # Ignoring since github.com/drand/kyber/sign/bls uses Proof Of Possession as does Ethereum.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Container for building Go binary.
-FROM golang:1.21.3-bullseye AS builder
+FROM golang:1.21.5-bullseye AS builder
 # Install dependencies
 RUN apt-get update && apt-get install -y build-essential git
 # Prep and copy source

--- a/app/app.go
+++ b/app/app.go
@@ -381,7 +381,7 @@ func eth2Client(ctx context.Context, bnURL string, valAmount uint64) (eth2wrap.C
 }
 
 // timeoutByValAmount returns the maximum timeout an eth2http call will have.
-// Return a timeout of (valAmount/50)*10, where 10 are the seconds to wait.
+// Return a timeout of (valAmount/50)*20, where 20 are the seconds to wait.
 func timeoutByValAmount(valAmount uint64) time.Duration {
 	rawRate := float64(valAmount) / float64(50)
 	rate := uint64(math.Ceil(rawRate))

--- a/app/app_internal_test.go
+++ b/app/app_internal_test.go
@@ -47,7 +47,7 @@ func Test_eth2Client(t *testing.T) {
 
 	ctx := context.Background()
 
-	client, err := eth2Client(ctx, srv.URL)
+	client, err := eth2Client(ctx, srv.URL, 1)
 	require.NoError(t, err)
 
 	vals, err := client.Validators(ctx, &eth2api.ValidatorsOpts{

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -31,7 +31,7 @@ import (
 const exitEpoch = eth2p0.Epoch(194048)
 
 func Test_NormalFlow(t *testing.T) {
-	valAmt := 4
+	valAmt := 100
 	operatorAmt := 4
 
 	lock, enrs, keyShares := cluster.NewForT(


### PR DESCRIPTION
Explicitly set beacon node query timeouts to `(validatorAmount/50)*20 seconds`.

This also sets the amount of validator to query in each chunk -- which is done internally by `go-eth2-client` -- to 50.

This should allow even the worst-performing beacon nodes to still fetch data.

category: bug
ticket: none