### PR TITLE
app: interact with API more often

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -46,6 +46,7 @@ type Config struct {
 
 const (
 	maxBeaconNodeTimeout = 10 * time.Second
+	obolAPITimeout       = 10 * time.Second
 )
 
 // Run runs the lido-dv-exit core logic.
@@ -259,9 +260,9 @@ func writeAllFullExits(
 }
 
 // fetchFullExit returns true if a full exit was received from the Obol API, and was written in exitFSPath.
-// Each HTTP request has a 10 seconds timeout.
+// Each HTTP request has a default timeout.
 func fetchFullExit(ctx context.Context, eth2Cl eth2wrap.Client, oAPI obolapi.Client, lockHash []byte, validatorPubkey, exitFSPath string, shareIndex uint64, identityKey *k1.PrivateKey) bool {
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, obolAPITimeout)
 	defer cancel()
 
 	fullExit, err := oAPI.GetFullExit(ctx, validatorPubkey, lockHash, shareIndex, identityKey)
@@ -325,9 +326,9 @@ func fetchFullExit(ctx context.Context, eth2Cl eth2wrap.Client, oAPI obolapi.Cli
 	return true
 }
 
-// postPartialExit posts exitBlobs to Obol API with a 10 seconds HTTP request deadline.
+// postPartialExit posts exitBlobs to Obol API with a default HTTP request timeout.
 func postPartialExit(ctx context.Context, oAPI obolapi.Client, mutationHash []byte, shareIndex uint64, identityKey *k1.PrivateKey, exitBlobs ...obolapi.ExitBlob) error {
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, obolAPITimeout)
 	defer cancel()
 
 	if err := oAPI.PostPartialExit(ctx, mutationHash, shareIndex, identityKey, exitBlobs...); err != nil {

--- a/app/app_internal_test.go
+++ b/app/app_internal_test.go
@@ -72,7 +72,7 @@ func Test_newSlotTicker(t *testing.T) {
 		cluster.WithVersion("v1.7.0"),
 	)
 
-	srvs := ldetestutil.APIServers(t, lock)
+	srvs := ldetestutil.APIServers(t, lock, false)
 	defer srvs.Close()
 
 	clock := clockwork.NewFakeClock()


### PR DESCRIPTION
Instead of waiting that *all* partial exits have been calculated before posting them to API, do that whenever we have a chance to do that.

Also, download and process full exits on the epoch boundary instead of waiting that the previous process has completed.

category: bug
ticket: none