### PR TITLE
cmd: pubkey query chunk size

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -36,12 +36,13 @@ import (
 
 // Config is the lido-dv-exit CLI configuration flag value holder.
 type Config struct {
-	Log              log.Config
-	BeaconNodeURL    string
-	EjectorExitPath  string
-	CharonRuntimeDir string
-	ExitEpoch        uint64
-	ObolAPIURL       string
+	Log                     log.Config
+	BeaconNodeURL           string
+	EjectorExitPath         string
+	CharonRuntimeDir        string
+	ExitEpoch               uint64
+	ObolAPIURL              string
+	ValidatorQueryChunkSize int
 }
 
 const (
@@ -97,7 +98,7 @@ func Run(ctx context.Context, config Config) error {
 		return err
 	}
 
-	bnClient, err := eth2Client(ctx, config.BeaconNodeURL, uint64(len(valsKeys)))
+	bnClient, err := eth2Client(ctx, config.BeaconNodeURL, uint64(len(valsKeys)), config.ValidatorQueryChunkSize)
 	if err != nil {
 		return errors.Wrap(err, "can't connect to beacon node")
 	}
@@ -389,12 +390,12 @@ func sigDataForExit(ctx context.Context, exit eth2p0.VoluntaryExit, eth2Cl eth2w
 }
 
 // eth2Client initializes an eth2 beacon node API client.
-func eth2Client(ctx context.Context, bnURL string, valAmount uint64) (eth2wrap.Client, error) {
+func eth2Client(ctx context.Context, bnURL string, valAmount uint64, chunkSize int) (eth2wrap.Client, error) {
 	bnHTTPClient, err := eth2http.New(ctx,
 		eth2http.WithAddress(bnURL),
 		eth2http.WithLogLevel(1), // zerolog.InfoLevel
 		eth2http.WithTimeout(timeoutByValAmount(valAmount)),
-		eth2http.WithPubKeyChunkSize(50),
+		eth2http.WithPubKeyChunkSize(chunkSize),
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "can't connect to beacon node")

--- a/app/app_internal_test.go
+++ b/app/app_internal_test.go
@@ -47,7 +47,7 @@ func Test_eth2Client(t *testing.T) {
 
 	ctx := context.Background()
 
-	client, err := eth2Client(ctx, srv.URL, 1)
+	client, err := eth2Client(ctx, srv.URL, 1, 1)
 	require.NoError(t, err)
 
 	vals, err := client.Validators(ctx, &eth2api.ValidatorsOpts{

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -200,11 +200,12 @@ func run(
 				Format: "console",
 				Color:  "false",
 			},
-			BeaconNodeURL:    servers.BeaconNodeServer.URL,
-			EjectorExitPath:  filepath.Join(ejectorDir, opID),
-			CharonRuntimeDir: filepath.Join(root, opID),
-			ObolAPIURL:       servers.ObolAPIServer.URL,
-			ExitEpoch:        194048,
+			BeaconNodeURL:           servers.BeaconNodeServer.URL,
+			EjectorExitPath:         filepath.Join(ejectorDir, opID),
+			CharonRuntimeDir:        filepath.Join(root, opID),
+			ObolAPIURL:              servers.ObolAPIServer.URL,
+			ExitEpoch:               194048,
+			ValidatorQueryChunkSize: 1,
 		}
 	}
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -36,6 +36,7 @@ func newRunCmd(root *cobra.Command, conf app.Config, entrypoint func(ctx context
 	cmd.Flags().StringVarP(&conf.CharonRuntimeDir, "charon-runtime-dir", "c", "", "Charon directory, containing the validator_keys directory and manifest file or lock file.")
 	cmd.Flags().StringVarP(&conf.ObolAPIURL, "obol-api-url", "o", "https://api.obol.tech", "URL pointing to an obol API instance.")
 	cmd.Flags().Uint64Var(&conf.ExitEpoch, "exit-epoch", 194048, "Epoch to exit validators at.")
+	cmd.Flags().IntVar(&conf.ValidatorQueryChunkSize, "validator-query-chunk-size", 50, "Chunk size for validator querying. Lower this value if you see many context timeout on validator state beacon node query.")
 
 	bindLogFlags(cmd.Flags(), &conf.Log)
 	bindLokiFlags(cmd.Flags(), &conf.Log)
@@ -43,6 +44,10 @@ func newRunCmd(root *cobra.Command, conf app.Config, entrypoint func(ctx context
 	wrapPreRunE(cmd, func(cmd *cobra.Command, args []string) error {
 		if _, err := url.ParseRequestURI(conf.BeaconNodeURL); err != nil {
 			return errors.New("beacon-node-url does not contain a vaild URL")
+		}
+
+		if conf.ValidatorQueryChunkSize <= 0 {
+			return errors.New("validator query chunk size cannot be less or equal to 0")
 		}
 
 		if err := dirWritable(conf.EjectorExitPath); err != nil {


### PR DESCRIPTION
Allow setting the amount of chunking for validator state query on beacon node.

Useful for slow beacon nodes, or networks where there is a high number of validators (like Holesky).

category: feature
ticket: none