### PR TITLE
app/obolapi: ignore empty partial signatures

### DIFF
--- a/app/obolapi/obolapi.go
+++ b/app/obolapi/obolapi.go
@@ -198,6 +198,11 @@ func (c Client) GetFullExit(ctx context.Context, valPubkey string, lockHash []by
 	rawSignatures := make(map[int]tbls.Signature)
 
 	for sigIdx, sigStr := range er.Signatures {
+		if len(sigStr) == 0 {
+			// ignore, the associated share index didn't push a partial signature yet
+			continue
+		}
+
 		if len(sigStr) < 2 {
 			return ExitBlob{}, errors.New("signature string has invalid size", z.Int("size", len(sigStr)))
 		}

--- a/app/util/testutil/api_servers.go
+++ b/app/util/testutil/api_servers.go
@@ -56,7 +56,7 @@ func (ts *TestServers) Eth2Client(t *testing.T, ctx context.Context) eth2wrap.Cl
 func APIServers(t *testing.T, lock cluster.Lock, withNonActiveVals bool) TestServers {
 	t.Helper()
 
-	oapiHandler, oapiAddLock := obolapi.MockServer()
+	oapiHandler, oapiAddLock := obolapi.MockServer(false)
 	oapiAddLock(lock)
 
 	oapiServer := httptest.NewServer(oapiHandler)

--- a/cmd/mockservers.go
+++ b/cmd/mockservers.go
@@ -38,7 +38,7 @@ type bmockCliConfig struct {
 func newMockServersCmd(
 	root *cobra.Command,
 	bnapiMock func(ctx context.Context, validators map[string]eth2v1.Validator, bindAddr string) error,
-	obolAPIMock func(_ context.Context, bind string, locks []cluster.Lock) error,
+	obolAPIMock func(_ context.Context, bind string, locks []cluster.Lock, _ bool) error,
 ) {
 	bcc := bmockCliConfig{
 		Validators: map[string]eth2v1.Validator{},
@@ -141,7 +141,7 @@ func runMockServers(
 	cmd *cobra.Command,
 	conf bmockCliConfig,
 	bnapiMock func(ctx context.Context, validators map[string]eth2v1.Validator, bindAddr string) error,
-	obolAPIMock func(_ context.Context, bind string, locks []cluster.Lock) error,
+	obolAPIMock func(_ context.Context, bind string, locks []cluster.Lock, _ bool) error,
 ) error {
 	if err := log.InitLogger(conf.Log); err != nil {
 		return err
@@ -158,7 +158,7 @@ func runMockServers(
 	})
 
 	eg.Go(func() error {
-		return obolAPIMock(ctx, conf.ObolAPIBind, conf.LockFiles)
+		return obolAPIMock(ctx, conf.ObolAPIBind, conf.LockFiles, false)
 	})
 
 	if err := eg.Wait(); err != nil {


### PR DESCRIPTION
API will return partial signatures iff there are at least threshold of them, which also means we could find `null`'s in the response.

Since the partial signatures array returned by the API maps 1:1 with the corresponding share index, we need to ignore empty ones to keep going with the aggregation process.

We still error if the signature is longer than 0 bytes but no more than 2.

Added a test case to cover the issue as well.

category: bug
ticket: none