### PR TITLE
app: sign with Capella domain

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   # First run code formatters
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.1.0
     hooks:
       - id: trailing-whitespace # trims trailing whitespace
         exclude: "testdata"
@@ -12,10 +12,10 @@ repos:
       - id: no-commit-to-branch # Protect specific branches (default: main/master) from direct checkins
 
   - repo: https://github.com/ObolNetwork/go-pre-commit-hooks
-    rev: v0.0.2
+    rev: v0.0.3
     hooks:
       - id: check-go-version
-        args: [ -v=go1.20 ] # Only check minor version locally
+        args: [ -v=go1.22 ] # Only check minor version locally
         pass_filenames: false
         additional_dependencies: [ packaging ]
       - id: check-licence-header
@@ -28,13 +28,13 @@ repos:
       - id: go-fiximports # format imports for go source files
 
   - repo: https://github.com/tekwizely/pre-commit-golang
-    rev: v1.0.0-rc.1 # cannot use master as it is a mutable reference and is not supported
+    rev: v1.0.0-beta.5 # cannot use master as it is a mutable reference and is not supported
     hooks:
       - id: go-mod-tidy
         files: go.mod
 
   - repo: https://github.com/dnephin/pre-commit-golang
-    rev: v0.5.1
+    rev: v0.4.0
     hooks:
       - id: go-fmt
         args: [ -w, -s ] # simplify code and write result to (source) file instead of stdout
@@ -42,7 +42,7 @@ repos:
   # Then run code validators (on the formatted code)
 
   - repo: https://github.com/golangci/golangci-lint # See .golangci.yml for config
-    rev: v1.54.2
+    rev: v1.56.2
     hooks:
       - id: golangci-lint
 

--- a/LICENSE
+++ b/LICENSE
@@ -10,7 +10,7 @@ Parameters
 Licensor:             Obol Labs, Inc.
 
 Licensed Work:        lido-dv-exit
-                      The Licensed Work is © 2022-2023 Obol Labs, Inc.
+                      The Licensed Work is © 2022-2024 Obol Labs, Inc.
 
 Additional Use Grant: The use of the Licensed Work by the Licensee is limited
                       to one distributed validator on a production network.

--- a/app/app.go
+++ b/app/app.go
@@ -1,7 +1,5 @@
 // Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
-// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
-
 package app
 
 import (

--- a/app/app.go
+++ b/app/app.go
@@ -1,3 +1,5 @@
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
 // Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package app
@@ -25,7 +27,6 @@ import (
 	"github.com/obolnetwork/charon/app/log"
 	"github.com/obolnetwork/charon/app/z"
 	manifestpb "github.com/obolnetwork/charon/cluster/manifestpb/v1"
-	"github.com/obolnetwork/charon/eth2util/signing"
 	"github.com/obolnetwork/charon/p2p"
 	"github.com/obolnetwork/charon/tbls"
 	"github.com/obolnetwork/charon/tbls/tblsconv"
@@ -115,6 +116,16 @@ func Run(ctx context.Context, config Config) error {
 		return errors.Wrap(err, "cannot fetch genesis spec")
 	}
 
+	genesis, err := bnClient.Genesis(ctx, &eth2api.GenesisOpts{})
+	if err != nil {
+		return errors.Wrap(err, "cannot fetch genesis")
+	}
+
+	capellaForkHash, err := bnapi.CapellaFork("0x" + hex.EncodeToString(genesis.Data.GenesisForkVersion[:]))
+	if err != nil {
+		return errors.Wrap(err, "fork hash conversion")
+	}
+
 	rawSlotsPerEpoch, ok := specResp.Data["SLOTS_PER_EPOCH"]
 	if !ok {
 		return errors.Wrap(err, "spec field SLOTS_PER_EPOCH not found in spec")
@@ -144,7 +155,6 @@ func Run(ctx context.Context, config Config) error {
 			if len(fetchedSignedExits) != len(signedExits) {
 				writeAllFullExits(
 					ctx,
-					bnClient,
 					oAPI,
 					cl,
 					signedExits,
@@ -152,6 +162,9 @@ func Run(ctx context.Context, config Config) error {
 					config.EjectorExitPath,
 					shareIdx,
 					identityKey,
+					genesis.Data.GenesisValidatorsRoot,
+					capellaForkHash,
+					specResp.Data,
 				)
 
 				continue
@@ -219,7 +232,14 @@ func Run(ctx context.Context, config Config) error {
 			}
 
 			// sign exit
-			exit, err := signExit(ctx, bnClient, valIndex, valKeyShare.Share, eth2p0.Epoch(config.ExitEpoch))
+			exit, err := signExit(
+				valIndex,
+				valKeyShare.Share,
+				eth2p0.Epoch(config.ExitEpoch),
+				genesis.Data.GenesisValidatorsRoot,
+				capellaForkHash,
+				specResp.Data,
+			)
 			if err != nil {
 				log.Error(ctx, "Cannot sign exit", err)
 				continue
@@ -247,7 +267,6 @@ func Run(ctx context.Context, config Config) error {
 
 		writeAllFullExits(
 			ctx,
-			bnClient,
 			oAPI,
 			cl,
 			signedExits,
@@ -255,6 +274,9 @@ func Run(ctx context.Context, config Config) error {
 			config.EjectorExitPath,
 			shareIdx,
 			identityKey,
+			genesis.Data.GenesisValidatorsRoot,
+			capellaForkHash,
+			specResp.Data,
 		)
 	}
 
@@ -266,7 +288,6 @@ func Run(ctx context.Context, config Config) error {
 // writeAllFullExits fetches and writes signedExits to disk.
 func writeAllFullExits(
 	ctx context.Context,
-	eth2Cl eth2wrap.Client,
 	oAPI obolapi.Client,
 	cl *manifestpb.Cluster,
 	signedExits []obolapi.ExitBlob,
@@ -274,6 +295,9 @@ func writeAllFullExits(
 	ejectorExitPath string,
 	shareIndex uint64,
 	identityKey *k1.PrivateKey,
+	genesisValidatorRoot eth2p0.Root,
+	forkHash string,
+	spec map[string]any,
 ) {
 	for _, signedExit := range signedExits {
 		if _, ok := alreadySignedExits[signedExit.PublicKey]; ok {
@@ -282,7 +306,18 @@ func writeAllFullExits(
 
 		exitFSPath := filepath.Join(ejectorExitPath, fmt.Sprintf("validator-exit-%s.json", signedExit.PublicKey))
 
-		if !fetchFullExit(ctx, eth2Cl, oAPI, cl.InitialMutationHash, signedExit.PublicKey, exitFSPath, shareIndex, identityKey) {
+		if !fetchFullExit(
+			ctx,
+			oAPI,
+			cl.GetInitialMutationHash(),
+			signedExit.PublicKey,
+			exitFSPath,
+			shareIndex,
+			identityKey,
+			genesisValidatorRoot,
+			forkHash,
+			spec,
+		) {
 			log.Debug(ctx, "Could not fetch full exit for validator", z.Str("validator", signedExit.PublicKey))
 			continue
 		}
@@ -293,7 +328,17 @@ func writeAllFullExits(
 
 // fetchFullExit returns true if a full exit was received from the Obol API, and was written in exitFSPath.
 // Each HTTP request has a default timeout.
-func fetchFullExit(ctx context.Context, eth2Cl eth2wrap.Client, oAPI obolapi.Client, lockHash []byte, validatorPubkey, exitFSPath string, shareIndex uint64, identityKey *k1.PrivateKey) bool {
+func fetchFullExit(
+	ctx context.Context,
+	oAPI obolapi.Client,
+	lockHash []byte,
+	validatorPubkey, exitFSPath string,
+	shareIndex uint64,
+	identityKey *k1.PrivateKey,
+	genesisValidatorRoot eth2p0.Root,
+	forkHash string,
+	spec map[string]any,
+) bool {
 	ctx, cancel := context.WithTimeout(ctx, obolAPITimeout)
 	defer cancel()
 
@@ -336,7 +381,7 @@ func fetchFullExit(ctx context.Context, eth2Cl eth2wrap.Client, oAPI obolapi.Cli
 		return false
 	}
 
-	exitRoot, err := sigDataForExit(ctx, *fullExit.SignedExitMessage.Message, eth2Cl, fullExit.SignedExitMessage.Message.Epoch)
+	exitRoot, err := sigDataForExit(*fullExit.SignedExitMessage.Message, genesisValidatorRoot, forkHash, spec)
 	if err != nil {
 		log.Error(ctx, "Cannot calculate hash tree root for exit message for verification", err)
 
@@ -378,13 +423,20 @@ func shouldProcessValidator(v *eth2v1.Validator) bool {
 
 // signExit signs a voluntary exit message for valIdx with the given keyShare.
 // Adapted from charon.
-func signExit(ctx context.Context, eth2Cl eth2wrap.Client, valIdx eth2p0.ValidatorIndex, keyShare tbls.PrivateKey, exitEpoch eth2p0.Epoch) (eth2p0.SignedVoluntaryExit, error) {
+func signExit(
+	valIdx eth2p0.ValidatorIndex,
+	keyShare tbls.PrivateKey,
+	exitEpoch eth2p0.Epoch,
+	genesisValidatorRoot eth2p0.Root,
+	forkHash string,
+	spec map[string]any,
+) (eth2p0.SignedVoluntaryExit, error) {
 	exit := &eth2p0.VoluntaryExit{
 		Epoch:          exitEpoch,
 		ValidatorIndex: valIdx,
 	}
 
-	sigData, err := sigDataForExit(ctx, *exit, eth2Cl, exitEpoch)
+	sigData, err := sigDataForExit(*exit, genesisValidatorRoot, forkHash, spec)
 	if err != nil {
 		return eth2p0.SignedVoluntaryExit{}, errors.Wrap(err, "exit hash tree root")
 	}
@@ -400,16 +452,31 @@ func signExit(ctx context.Context, eth2Cl eth2wrap.Client, valIdx eth2p0.Validat
 	}, nil
 }
 
-// sigDataForExit returns the hash tree root for the given exit message, at the given exit epoch.
-func sigDataForExit(ctx context.Context, exit eth2p0.VoluntaryExit, eth2Cl eth2wrap.Client, exitEpoch eth2p0.Epoch) ([32]byte, error) {
+// sigDataForExit returns the hash tree root for the given exit message.
+func sigDataForExit(
+	exit eth2p0.VoluntaryExit,
+	genesisValidatorRoot eth2p0.Root,
+	forkHash string,
+	spec map[string]any,
+) ([32]byte, error) {
 	sigRoot, err := exit.HashTreeRoot()
 	if err != nil {
 		return [32]byte{}, errors.Wrap(err, "exit hash tree root")
 	}
 
-	domain, err := signing.GetDomain(ctx, eth2Cl, signing.DomainExit, exitEpoch)
+	domainType, ok := spec["DOMAIN_VOLUNTARY_EXIT"]
+	if !ok {
+		return [32]byte{}, errors.New("domain type not found")
+	}
+
+	domainTyped, ok := domainType.(eth2p0.DomainType)
+	if !ok {
+		return [32]byte{}, errors.New("invalid domain type")
+	}
+
+	domain, err := bnapi.ComputeDomain(forkHash, domainTyped, genesisValidatorRoot)
 	if err != nil {
-		return [32]byte{}, errors.Wrap(err, "get domain")
+		return [32]byte{}, err
 	}
 
 	sigData, err := (&eth2p0.SigningData{ObjectRoot: sigRoot, Domain: domain}).HashTreeRoot()

--- a/app/app.go
+++ b/app/app.go
@@ -118,7 +118,7 @@ func Run(ctx context.Context, config Config) error {
 
 	genesis, err := bnClient.Genesis(ctx, &eth2api.GenesisOpts{})
 	if err != nil {
-		return errors.Wrap(err, "cannot fetch genesis")
+		return errors.Wrap(err, "fetching genesis")
 	}
 
 	capellaForkHash, err := bnapi.CapellaFork("0x" + hex.EncodeToString(genesis.Data.GenesisForkVersion[:]))

--- a/app/app_internal_test.go
+++ b/app/app_internal_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package app
 

--- a/app/app_internal_test.go
+++ b/app/app_internal_test.go
@@ -1,5 +1,3 @@
-// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
-
 // Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package app

--- a/app/app_internal_test.go
+++ b/app/app_internal_test.go
@@ -1,3 +1,5 @@
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
 // Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package app

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -1,7 +1,5 @@
 // Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
-// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
-
 package app_test
 
 import (

--- a/app/bnapi/bnapi.go
+++ b/app/bnapi/bnapi.go
@@ -1,7 +1,5 @@
 // Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
-// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
-
 package bnapi
 
 import (

--- a/app/bnapi/bnapi_test.go
+++ b/app/bnapi/bnapi_test.go
@@ -1,0 +1,46 @@
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package bnapi_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ObolNetwork/lido-dv-exit/app/bnapi"
+)
+
+func TestCapellaFork(t *testing.T) {
+	tests := []struct {
+		name      string
+		forkHash  string
+		want      string
+		errAssert require.ErrorAssertionFunc
+	}{
+		{
+			"bad fork hash string",
+			"bad",
+			"",
+			require.Error,
+		},
+		{
+			"ok fork hash but nonexistent",
+			"0x12345678",
+			"",
+			require.Error,
+		},
+		{
+			"existing ok fork hash",
+			"0x00000000",
+			"0x03000000",
+			require.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := bnapi.CapellaFork(tt.forkHash)
+			tt.errAssert(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/app/keystore/keystore.go
+++ b/app/keystore/keystore.go
@@ -1,4 +1,4 @@
-// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package keystore
 

--- a/app/keystore/keystore.go
+++ b/app/keystore/keystore.go
@@ -1,5 +1,3 @@
-// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
-
 // Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package keystore

--- a/app/keystore/keystore.go
+++ b/app/keystore/keystore.go
@@ -1,3 +1,5 @@
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
 // Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package keystore

--- a/app/keystore/keystore_test.go
+++ b/app/keystore/keystore_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package keystore_test
 

--- a/app/keystore/keystore_test.go
+++ b/app/keystore/keystore_test.go
@@ -1,3 +1,5 @@
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
 // Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package keystore_test

--- a/app/keystore/keystore_test.go
+++ b/app/keystore/keystore_test.go
@@ -1,5 +1,3 @@
-// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
-
 // Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package keystore_test

--- a/app/obolapi/model.go
+++ b/app/obolapi/model.go
@@ -1,4 +1,4 @@
-// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package obolapi
 

--- a/app/obolapi/model.go
+++ b/app/obolapi/model.go
@@ -1,5 +1,3 @@
-// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
-
 // Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package obolapi

--- a/app/obolapi/model.go
+++ b/app/obolapi/model.go
@@ -1,3 +1,5 @@
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
 // Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package obolapi

--- a/app/obolapi/obolapi.go
+++ b/app/obolapi/obolapi.go
@@ -1,4 +1,4 @@
-// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package obolapi
 

--- a/app/obolapi/obolapi.go
+++ b/app/obolapi/obolapi.go
@@ -1,5 +1,3 @@
-// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
-
 // Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package obolapi

--- a/app/obolapi/obolapi.go
+++ b/app/obolapi/obolapi.go
@@ -1,3 +1,5 @@
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
 // Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package obolapi

--- a/app/obolapi/obolapi_test.go
+++ b/app/obolapi/obolapi_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package obolapi_test
 

--- a/app/obolapi/obolapi_test.go
+++ b/app/obolapi/obolapi_test.go
@@ -1,3 +1,5 @@
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
 // Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package obolapi_test

--- a/app/obolapi/obolapi_test.go
+++ b/app/obolapi/obolapi_test.go
@@ -1,5 +1,3 @@
-// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
-
 // Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package obolapi_test

--- a/app/obolapi/test_server.go
+++ b/app/obolapi/test_server.go
@@ -1,4 +1,4 @@
-// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package obolapi
 

--- a/app/obolapi/test_server.go
+++ b/app/obolapi/test_server.go
@@ -1,5 +1,3 @@
-// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
-
 // Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package obolapi

--- a/app/obolapi/test_server.go
+++ b/app/obolapi/test_server.go
@@ -1,3 +1,5 @@
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
 // Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package obolapi

--- a/app/slot_ticker.go
+++ b/app/slot_ticker.go
@@ -1,4 +1,4 @@
-// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package app
 

--- a/app/slot_ticker.go
+++ b/app/slot_ticker.go
@@ -1,5 +1,3 @@
-// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
-
 // Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package app

--- a/app/slot_ticker.go
+++ b/app/slot_ticker.go
@@ -1,3 +1,5 @@
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
 // Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package app

--- a/app/util/testutil/api_servers.go
+++ b/app/util/testutil/api_servers.go
@@ -1,4 +1,4 @@
-// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package testutil
 

--- a/app/util/testutil/api_servers.go
+++ b/app/util/testutil/api_servers.go
@@ -1,5 +1,3 @@
-// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
-
 // Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package testutil

--- a/app/util/testutil/api_servers.go
+++ b/app/util/testutil/api_servers.go
@@ -1,3 +1,5 @@
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
 // Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package testutil

--- a/app/util/util.go
+++ b/app/util/util.go
@@ -1,3 +1,5 @@
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
 // Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package util
@@ -23,6 +25,9 @@ const (
 
 	// k1SignatureLen is the amount of bytes a well-formed K1 signature must contain.
 	k1SignatureLen = 65
+
+	// forkHashLen is the amount of bytes a well-formed Ethereum fork hash must contain.
+	forkHashLen = 4
 )
 
 // from0x decodes hex-encoded data and expects it to be exactly of len(length).
@@ -44,6 +49,12 @@ func from0x(data string, length int) ([]byte, error) {
 	}
 
 	return b, nil
+}
+
+// ForkHashToBytes returns the bytes representation of the Ethereum fork hash string passed in input.
+// If forkHAsh is empty, contains badly-formatted hex data or doesn't yield exactly 4 bytes, this function will error.
+func ForkHashToBytes(forkHash string) ([]byte, error) {
+	return from0x(forkHash, forkHashLen)
 }
 
 // ValidatorPubkeyToBytes returns the bytes representation of the validator hex-encoded public key string passed in input.

--- a/app/util/util.go
+++ b/app/util/util.go
@@ -1,7 +1,5 @@
 // Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
-// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
-
 package util
 
 import (

--- a/app/util/util_test.go
+++ b/app/util/util_test.go
@@ -1,3 +1,5 @@
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
 // Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package util_test
@@ -195,6 +197,55 @@ func TestK1SignatureToBytes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := util.K1SignatureToBytes(tt.pubkey)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Empty(t, got)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestForkHashToBytes(t *testing.T) {
+	tests := []struct {
+		name    string
+		pubkey  string
+		want    []byte
+		wantErr bool
+	}{
+		{
+			"empty input",
+			"",
+			nil,
+			true,
+		},
+		{
+			"not 4 bytes",
+			hex.EncodeToString([]byte{1, 2, 3}),
+			nil,
+			true,
+		},
+		{
+			"4 bytes 0x-prefixed work",
+			"0x" + hex.EncodeToString(bytes.Repeat([]byte{42}, 4)),
+			bytes.Repeat([]byte{42}, 4),
+			false,
+		},
+		{
+			"4 bytes non-0x-prefixed work",
+			hex.EncodeToString(bytes.Repeat([]byte{42}, 4)),
+			bytes.Repeat([]byte{42}, 4),
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := util.ForkHashToBytes(tt.pubkey)
 			if tt.wantErr {
 				require.Error(t, err)
 				require.Empty(t, got)

--- a/app/util/util_test.go
+++ b/app/util/util_test.go
@@ -1,7 +1,5 @@
 // Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
-// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
-
 package util_test
 
 import (

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -1,4 +1,4 @@
-// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package cmd
 

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -1,5 +1,3 @@
-// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
-
 // Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package cmd

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -1,3 +1,5 @@
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
 // Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package cmd

--- a/cmd/mockservers.go
+++ b/cmd/mockservers.go
@@ -1,4 +1,4 @@
-// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package cmd
 

--- a/cmd/mockservers.go
+++ b/cmd/mockservers.go
@@ -1,5 +1,3 @@
-// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
-
 // Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package cmd

--- a/cmd/mockservers.go
+++ b/cmd/mockservers.go
@@ -1,3 +1,5 @@
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
 // Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package cmd

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,4 +1,4 @@
-// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package cmd
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,5 +1,3 @@
-// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
-
 // Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package cmd

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,3 +1,5 @@
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
 // Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package cmd

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,4 +1,4 @@
-// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package cmd
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,5 +1,3 @@
-// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
-
 // Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package cmd

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,3 +1,5 @@
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
 // Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package cmd

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package main
 

--- a/main.go
+++ b/main.go
@@ -1,5 +1,3 @@
-// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
-
 // Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package main

--- a/main.go
+++ b/main.go
@@ -1,3 +1,5 @@
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
 // Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 package main


### PR DESCRIPTION
Following EIP-7044[1], sign exits with Capella domain for perpetual validity.

[1]: https://eips.ethereum.org/EIPS/eip-7044

category: bug
ticket: none