### PR TITLE
Bump go version in dockerfile and debian version

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -6,4 +6,4 @@ runs:
     - name: Setup go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.24.3'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Container for building Go binary.
-FROM golang:1.22.5-bullseye AS builder
+FROM golang:1.24.3-bookworm AS builder
 # Install dependencies
 RUN apt-get update && apt-get install -y build-essential git
 # Prep and copy source
@@ -17,7 +17,7 @@ RUN \
 RUN echo "Built lido-dv-exit version=$(./lido-dv-exit version)"
 
 # Copy final binary into light stage.
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y ca-certificates wget
 ARG GITHUB_SHA=local
 ENV GITHUB_SHA=${GITHUB_SHA}


### PR DESCRIPTION
The gh actions wasn't enough. This pr updates the golang version in the docker build stage, and also takes the opportunity to update from debian 11 to debian 12, in line with charon's docker image. 

category: fixbuild
ticket: none

