### PR TITLE
fix: pin GitHub Actions to SHA for supply chain security

### DIFF
--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     name: Build Docker Image
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         fetch-depth: 0
     - name: Fix binfmt flags with multiarch/qemu-user-static
       run: |
         docker run --rm --privileged multiarch/qemu-user-static --reset -p yes -c yes
-    - uses: docker/setup-buildx-action@v3
+    - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
     - name: Get version.Version from the code
       if: github.ref_type == 'branch'
@@ -24,7 +24,7 @@ jobs:
 
     - name: Define docker image meta data tags
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
       with:
         images: |
           obolnetwork/lido-dv-exit
@@ -42,7 +42,7 @@ jobs:
           type=ref,event=tag
 
     - name: Login to Dockerhub container registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
       with:
         username: obolnetwork
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -51,7 +51,7 @@ jobs:
       if: github.ref_type == 'tag'
       run: echo 'GO_BUILD_FLAG=-ldflags=-X github.com/obolnetwork/lido-dv-exit/version.version=${{ github.ref_name }}' >> $GITHUB_ENV
 
-    - uses: docker/build-push-action@v6
+    - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
       with:
         context: .
         platforms: linux/amd64,linux/arm64

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Config options can be found in README here: https://github.com/golangci/golangci-lint-action
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: ./.github/actions/setup-go
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
         with:
           version: v2.4.0

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       security-events: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ssh-key: ${{ secrets.DEPLOY_KEY }}
       - uses: ./.github/actions/setup-go

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -31,7 +31,7 @@ jobs:
           fi
           echo "label=$LABEL" >> $GITHUB_OUTPUT
 
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         if: steps.branch-label.outputs.label != 'skip'
         with:
           script: |

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,9 +10,9 @@ jobs:
     env:
       SKIP: golangci-lint,run-go-tests,no-commit-to-branch
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0 # Disable shallow checkout
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       - uses: ./.github/actions/setup-go
-      - uses: pre-commit/action@v3.0.1
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,13 +10,13 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         fetch-depth: 0 # Disable shallow checkout
     - uses: ./.github/actions/setup-go
     - run: go run . --help > cli-reference.txt
     - run: go run testutil/genchangelog/main.go
-    - uses: softprops/action-gh-release@v2
+    - uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
       with:
         draft: true
         files: cli-reference.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,9 @@ jobs:
   unit_tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: ./.github/actions/setup-go
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/go/pkg/mod
@@ -20,7 +20,7 @@ jobs:
             ${{ runner.os }}-go-
       - run: go test -coverprofile=coverage.out -covermode=atomic -timeout=5m -race ./...
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5.5.1
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.out

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -9,7 +9,7 @@ jobs:
     env:
       GITHUB_PR: ${{ toJSON(github.event.pull_request) }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: ./.github/actions/setup-go
       - name: "Verify PR"
         run: go run github.com/obolnetwork/charon/testutil/verifypr


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions `uses:` references to commit SHAs for supply chain security
- Original version tags preserved as inline comments for maintainability

## Changes
- All `uses: owner/action@tag` → `uses: owner/action@SHA # tag`

## Known pre-existing failures (not caused by this PR)
- `govulncheck`: 14 Go vulnerabilities in dependencies (go-ethereum, quic-go, stdlib). Requires major dep upgrades to fix.

## Test plan
- [x] Verify CI workflows run successfully
- [x] Confirm no action versions changed, only pinning format