### PR TITLE
*: bump build action

### DIFF
--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -51,7 +51,7 @@ jobs:
       if: github.ref_type == 'tag'
       run: echo 'GO_BUILD_FLAG=-ldflags=-X github.com/obolnetwork/lido-dv-exit/version.version=${{ github.ref_name }}' >> $GITHUB_ENV
 
-    - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+    - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
       with:
         context: .
         platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Builds seem to be failing with unrelated to our code issue. Likely a QEMU fault. This new version depends on QEMU action v4, rather than v3, so it will likely fix it.

category: misc
ticket: none
